### PR TITLE
New say commands

### DIFF
--- a/src/bot.rb
+++ b/src/bot.rb
@@ -69,11 +69,17 @@ class Bot
   end
 
   # Send an offline message to a target user.
+  #
+  # @param user [User] the user we want to send an offline message.
+  # @param msg [String] the offline message that is sent to user.
   def say_as_offline_message(user, msg)
     api.send_offline_message(user.id, msg)
   end
 
   # Send a message to the virual server the bot is currently logged in.
+  #
+  # @info: Such a message can be read globally in the server message channel.
+  # @param message [String] a message that is sent to the server channel.
   def say_to_server(message)
     api.send_server_message
   end

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -57,6 +57,27 @@ class Bot
     api.poke_client(user.id, msg)
   end
 
+  # Send a private message to a target user.
+  #
+  # @info: Private means that a separate chat-tab
+  #   between pigeon and the user is opened in which
+  #   all messages are send to.
+  # @param user [User] the user we want to send a private message.
+  # @param msg [String] private message that is sent to user.
+  def say_as_private(user, msg)
+    api.send_private_message(user.id, msg)
+  end
+
+  # Send an offline message to a target user.
+  def say_as_offline_message(user, msg)
+    api.send_offline_message(user.id, msg)
+  end
+
+  # Send a message to the virual server the bot is currently logged in.
+  def say_to_server(message)
+    api.send_server_message
+  end
+
   protected
 
   def perform_command(sender, message)

--- a/src/command.rb
+++ b/src/command.rb
@@ -32,10 +32,11 @@ class Command
 
   # list all available help files
   def self.help
-    @bot.say_in_current_channel("Available commands")
+    sender = Command.sender
+    @bot.say_as_private(sender, "Available commands")
     @all.keys.each do |cmd|
       description = CommandDescription.parse(cmd)
-      @bot.say_in_current_channel("!#{cmd.to_s} - #{description}")
+      @bot.say_as_private(sender, "!#{cmd.to_s} - #{description}")
     end
   end
 
@@ -51,7 +52,7 @@ class Command
       users = nicks.map { |nick| User.find_by_nick(nick) }
       users.flat_map { |u| UrlStore.urls(u.id) }
     end.sort.each do |url|
-      @bot.say_in_current_channel url.escaped
+      @bot.say_as_private(Command.sender, url.escaped)
     end
   end
 

--- a/src/command.rb
+++ b/src/command.rb
@@ -19,6 +19,13 @@ class Command
     @instr = instr
   end
 
+  # Try to invoke a given command by a user.
+  #
+  # @info: Invoking commands is guarded. A particular command
+  #   can only be invoked if the invoking user has enough priviliges
+  #   to invoe that command.
+  # @param user [User] sender of command
+  # @param args [Array] command name and its arguments
   def invoke_by(user, args)
     if user.level? @auth_level
       Command.sender = user


### PR DESCRIPTION
allow to send private, offline and global server messages to clients.
This reduces spaming the current channel and offers some private-ness.

`!ll` and `!h` are now using the `Bot#say_as_private` method.
