### PR TITLE
Drag and drop command

### DIFF
--- a/data/command_descriptions.yml
+++ b/data/command_descriptions.yml
@@ -1,6 +1,10 @@
-poke: Ping pigeon.
-ll: List all links posted by players. If passing an additional user name, all links of a certain user will be listed.
-bb: Shut down the pigeon process. Requires admin right.
-rs: Crawl random reddit stuff. If passing a additional argument a random post of a subreddit called the same as the passed argument will be fetched.
-rsi: Crawl a random reddit image.
-h: Show this message
+poke: Pokes the pigeon bot and he immediatly will poke you back. Acts as a ping method.
+ll: <NICKNAME> Lists all posted links. Providing <NICKNAME> will list all recently posted links by that particular user. Otherwise, all recently posted links (from any user) will be listed. Requires Normal privileges.
+bb: Shut down the pigeon process. Requires Server Admin privileges.
+rs: <SUBREDDIT> Crawls random posts from reddit. The argument <SUBREDDIT> is optional. It corresponds to a desired subreddit. If not specified, a random reddit post from the section new will be fetched. Requires Normal privileges.
+rsi: Crawls a random reddit image.
+rsw: Crawls a random reddit image from the subreddit wtf.
+dd: <NICKNAME> moves a given user that matches the nickname <NICKNAME> into the same channel as the command invoking user is located at. Requires Server Admin privileges.
+ot: Opens a private chat between the caller and pigeon. Allows to send commands to Sir Pigeon. Requires Normal privileges. 
+pm: <NICKNAME> send a message via Sir Pigeon to another target user matching a given nickname. Requires Normal privileges.
+h: Shows this message.

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -43,7 +43,10 @@ class Bot
     end
   end
 
-  # Move a given user to a target channel
+  # Move a given user to a target channel.
+  #
+  # @param user [User] target user that should be moved into given channel.
+  # @param channel_id [Integer] an id of an existing channel.
   def move_target(user, channel_id)
     api.move_client(user.id, channel_id)
   end

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -43,6 +43,11 @@ class Bot
     end
   end
 
+  # Move a given user to a target channel
+  def move_target(user, channel_id)
+    api.move_client(user.id, channel_id)
+  end
+
   # Send a given message into the channel in which the bot
   # pigeon is currently located. This message can be read by
   # all client that are currently in this channel.

--- a/src/bot.rb
+++ b/src/bot.rb
@@ -43,7 +43,7 @@ class Bot
     end
   end
 
-  # Move a given user to a target channel.
+  # Move a given user into a target channel.
   #
   # @param user [User] target user that should be moved into given channel.
   # @param channel_id [Integer] an id of an existing channel.

--- a/src/command.rb
+++ b/src/command.rb
@@ -43,6 +43,8 @@ class Command
   # drags a client by its nick (fuzzy) to the channel
   # where the command sender is currently in.
   #
+  # @info: Only partial match is required. Movement is applied to
+  #   every user retrieved by fuzzy finder.
   # @param fuzzy_nick [String] name of user to be dragged
   def self.drag_and_drop(fuzzy_nick)
     matches = User.try_find_all_by_nick(fuzzy_nick)

--- a/src/command.rb
+++ b/src/command.rb
@@ -55,7 +55,7 @@ class Command
   end
 
   def self.open_terminal
-    @bot.say_as_private(Command.sender, "How can I serve you?")
+    @bot.say_as_private(Command.sender, "How may I serve you?")
   end
 
   def self.poke

--- a/src/command.rb
+++ b/src/command.rb
@@ -10,6 +10,7 @@ class Command
       :pm => Command.new(ServerGroup.normal) { |args| pm_to(args[0], args[1]) },
       :rsw => Command.new(ServerGroup.normal) { crawl_wtf },
       :ot => Command.new(ServerGroup.normal) { open_terminal},
+      :dd => Command.new(ServerGroup.server_admin) { |nick| drag_and_drop(nick.first) },
       :h => Command.new { help }
     }
   end
@@ -36,6 +37,20 @@ class Command
     else
       msg = "You do not have permission to use this command!"
       Command.let_bot_say(Command.sender, msg)
+    end
+  end
+
+  # drags a client by its nick (fuzzy) to the channel
+  # where the command sender is currently in.
+  #
+  # @param fuzzy_nick [String] name of user to be dragged
+  def self.drag_and_drop(fuzzy_nick)
+    matches = User.try_find_all_by_nick(fuzzy_nick)
+    unless matches.empty?
+      sender = Command.sender
+      matches.each do |user|
+        @bot.move_target(user, sender.channel_id)
+      end
     end
   end
 

--- a/src/command.rb
+++ b/src/command.rb
@@ -84,9 +84,11 @@ class Command
     header = "Available commands: \n"
     help_msgs = @all.keys.map do |cmd|
       description = CommandDescription.parse(cmd)
-      "!#{cmd.to_s} - #{description} \n"
+      "!#{cmd.to_s} #{description} \n"
     end
-    @bot.say_as_private(sender, header+help_msgs.join)
+    msg_count = help_msgs.length
+    @bot.say_as_private(sender, "[1/2] " + header + help_msgs.first(5).join)
+    @bot.say_as_private(sender, "[2/2] " + header + help_msgs.last(msg_count-5).join)
   end
 
   def self.leave_server

--- a/src/user.rb
+++ b/src/user.rb
@@ -5,7 +5,7 @@
 # E.g. the logic behing the '!ll' command.
 class User
 
-  attr_reader :id, :nick
+  attr_reader :id, :nick, :channel_id
 
   # Returns a nil user used to represnt and fetch an incorrect user state.
   #


### PR DESCRIPTION
Introduced new command **drag and drop** `!dd`

`!dd <NICKNAME>` moves all users that partially match a provided NICKNAME to the channel the command invoking user is located at.

Scenario: User u1 is in channel A and User u2 is in channel B. u1 wants to move u2 into his current channel without having to know where u2 actually is. 

With this patch, u1 can achieve this goal by invoking `!dd u1`
