### PR TITLE
Allow to define custom permission lvls defined by the ts3 server

### DIFF
--- a/src/server.rb
+++ b/src/server.rb
@@ -30,12 +30,14 @@ class Server
 
   # Retrive a list of all available server groups.
   #
-  # @return [Hash{ServerGroupId => ServerGroupName}] list of all server groups.
+  # @return [Hash{ServerGroupId => [ServerGroupName, SortId]}] list of all server groups.
   def self.groups
     server_groups = api.get_server_groups
     return {} if server_groups.nil?
-    scg = server_groups.map {|cg| [cg.get_id, cg.get_name]}
-    Hash[*scg.flatten]
+    g_keys = server_groups.map {|cg| cg.get_id}
+    g_values = server_groups.map {|cg| [cg.get_name, cg.get_sort_id]}
+    scg = g_keys.zip(g_values)
+    Hash[scg]
   end
 
   # Retrive a list of all available server channels.
@@ -62,6 +64,11 @@ class Server
     end
     @api = @query.get_api
     @api.select_virtual_server_by_id(1)
+    $has_sort_values = Server.groups.values.any? do |group|
+      group[1] > 0
+    end
+    info = $has_sort_values ? "SORT IDS" : "IDS"
+    puts "Pigeon Info: Use group #{info} for determing permissions."
   end
 
   # Stop running this server.

--- a/src/server_group.rb
+++ b/src/server_group.rb
@@ -4,7 +4,7 @@
 #   (i.e. a user with only a few rights).
 class ServerGroup
 
-  attr_reader :id, :name
+  attr_reader :id, :name, :rank
 
   include Comparable
 
@@ -13,13 +13,18 @@ class ServerGroup
   end
 
   def initialize(args)
-    @id = args[0].to_i
+    @id = args[0]
     @name = args[1]
+    @rank = args[2]
+  end
+
+  def sort_value
+    $has_sort_values ? rank : id
   end
 
   def self.find_by_name(a_name)
     findings = all.select do |group|
-      pretty_name = group.name.downcase.gsub(" ","_")
+      pretty_name = group.name.downcase.gsub(" ", "_")
       pretty_name == a_name
     end
   end
@@ -58,7 +63,7 @@ class ServerGroup
   #   this is why we have to use the times -1.
   # @param other [ServerGroup]
   def <=>(other)
-    -id <=> -other.id
+    -sort_value <=> -other.sort_value
   end
 
   def self.highest
@@ -70,7 +75,7 @@ class ServerGroup
   end
 
   def self.nil_group
-    @nil_group ||= ServerGroup.new([10000, "nil_group"])
+    @nil_group ||= ServerGroup.new([10000, "nil_group", 10000])
   end
 
   def self.fetch_groups
@@ -79,7 +84,7 @@ class ServerGroup
 
   def self.to_groups(list)
     list.to_a.map do |item|
-      ServerGroup.new(item)
+      ServerGroup.new(item.flatten)
     end
   end
 

--- a/src/user.rb
+++ b/src/user.rb
@@ -24,9 +24,12 @@ class User
     return [] if server_clients.nil?
     @users = server_clients.map do |client|
       group_ids = client.server_groups.map &:to_i
-      group_names = server_groups.values_at(*group_ids)
-      permission_levels = ServerGroup.to_groups group_id_names_hash(group_ids, group_names)
-      User.new(client.get_id, client.get_nickname, permission_levels, client.get_channel_id)
+      groups_client_belongs_to = server_groups.select do |id, _|
+        group_ids.include?(id)
+      end
+
+      permissions = ServerGroup.to_groups(groups_client_belongs_to)
+      User.new(client.get_id, client.get_nickname, permissions, client.get_channel_id)
     end
   end
 
@@ -136,20 +139,6 @@ class User
   def human?
     return false if @is_nil_user
     !bot?
-  end
-
-  protected
-
-  # Forms a Hash from two given equally sized arrays.
-  #
-  # @info: First array depicts the list of hash keys,
-  #   and the second array the hash values.
-  # @param ids [Array<Integer>] server group ids.
-  # @param names [Array<String>] server group names.
-  # @return [Hash{ServerGroupId=>ServerGroupName}] permission list.
-  def self.group_id_names_hash(ids, names)
-      levels = ids.zip(names)
-      Hash[*levels.flatten]
   end
 
 end


### PR DESCRIPTION
if existing, make use of the server_groups#sort_id value otherwise use
the group id as the sorting parameter.

this change makes it possible to have a server specified permission
system. before this change pigeon was considering the ids of the default
groups as the indicator of the permission lvl - which is true for a
default ts3 server configuration. however, when defining custom
permissions, this assumption is no more valid.

info: permission levels are defined as the follows:

a permission is basically a integer value. the lowever its value,
the higher the permission level (like in sport rankings).
a client may invoke/perform certain pigeon actions if and only if his
permission lvl is at least as high as the required permission level.
