### PR TITLE
Send at most 3 rtd messages a day per users

### DIFF
--- a/src/bot.rb
+++ b/src/bot.rb
@@ -50,7 +50,8 @@ class Bot
     tasks ||= [
       TimedTask.new(60.0, MoveAfkUsers.new),
       TimedTask.new(10.0, CheckMcServer.new),
-      TimedTask.new(3600.0, RollTheDice.new)
+      TimedTask.new(3600.0, RollTheDice.new),
+      TimedTask.new(3600.0, DayChecker.new)
     ]
   end
 

--- a/src/periodic_task.rb
+++ b/src/periodic_task.rb
@@ -61,6 +61,12 @@ class CheckMcServer < PeriodicTask
   end
 end
 
+class DayChecker < PeriodicTask
+  def task
+    Session.update_day
+  end
+end
+
 # Sends a random link, stored in TauntLinkStore to a random user.
 class RollTheDice < PeriodicTask
 

--- a/src/periodic_task.rb
+++ b/src/periodic_task.rb
@@ -61,6 +61,8 @@ class CheckMcServer < PeriodicTask
   end
 end
 
+# This periodic tasks updates the current day (value) stored in the session.
+# The update rate (frequency) is defined in the class Bot (currently once an hour).
 class DayChecker < PeriodicTask
   def task
     Session.update_day

--- a/src/session.rb
+++ b/src/session.rb
@@ -3,6 +3,8 @@
 # such as whether they re currently talking to cleverbot.
 class Session
 
+  RTD_THRESH = 3
+
   def self.instance
     @instance ||= Session.new
   end
@@ -43,14 +45,32 @@ class Session
     @users
   end
 
+  # Fetch all users that have a rtd count that is at most equal to a given
+  # threshold.
+  #
+  # @info: Select all user having a rtd count at most equal to
+  #   a given threshold value.
+  # @param rtd_count [Integer] max allowed rtd count
+  #   user may exhibit in order to be selected
+  # @return [Array<User>] a list of users having a rtd count at most eqaul
+  #   to a given threshold value.
+  def users_with_rtd_count(rtd_count)
+    users.select do |user|
+      user.rtd_count <= rtd_count
+    end
+  end
+
   # Retrieve a random user from the session
   #
   # @return [User, nil] a random user included in the session.
   def random_user
-    n = @users.count
+    in_range_users = users_with_rtd_count(RTD_THRESH)
+    n = in_range_users.count
     return if n==0
     idx = rand(0..n-1)
-    @users[idx]
+    user = in_range_users[idx]
+    user.inc_rtd unless user.nil?
+    user
   end
 
   # Add a user to the internal user list.

--- a/src/session.rb
+++ b/src/session.rb
@@ -29,6 +29,10 @@ class Session
     instance.users
   end
 
+  def self.update_day
+    instance.update_day
+  end
+
   # Load each user that is only into the session's memory.
   #
   # @info: This method is called right after the bot's startup phase.
@@ -39,6 +43,13 @@ class Session
     User.all.each do |user|
       append_to_userlist(user)
     end
+  end
+
+  # update the current session day
+  def update_day
+    prev_day = @current_day
+    @current_day = Time.now.day
+    users.each(&:reset_rtd_count) if prev_day != @current_day
   end
 
   def users
@@ -115,6 +126,7 @@ class Session
 
   def initialize
     @users = []
+    update_day
   end
 
   private

--- a/src/session.rb
+++ b/src/session.rb
@@ -45,13 +45,22 @@ class Session
     end
   end
 
-  # update the current session day
+  # Updates the current session day
+  #
+  # @info: The previous stored day value is compared against the current day value.
+  #   in case the day value has changed, the rtd counter of every user currently
+  #   held in the session is resetted.
+  #   nb: the rtd counter of a user is used to limit the number of rtd links
+  #   a particular user may receive per day.
   def update_day
     prev_day = @current_day
     @current_day = Time.now.day
     users.each(&:reset_rtd_count) if prev_day != @current_day
   end
 
+  # Return all online users stored in the
+  #
+  # @return [Array<User>] a list of all user currently online in the server.
   def users
     @users
   end

--- a/src/session.rb
+++ b/src/session.rb
@@ -70,6 +70,7 @@ class Session
   #
   # @info: Select all user having a rtd count at most equal to
   #   a given threshold value.
+  #
   # @param rtd_count [Integer] max allowed rtd count
   #   user may exhibit in order to be selected
   # @return [Array<User>] a list of users having a rtd count at most eqaul
@@ -80,7 +81,12 @@ class Session
     end
   end
 
-  # Retrieve a random user from the session
+  # Retrieve a random user from the session.
+  #
+  # @info: Only users that have a rtd counter lower than RTD_THRESH
+  #   can be retrieved. This prevents the Bot sending to many random
+  #   links the same user. This implies: Every user can at most receive
+  #   RTD_THRESH random links (via the rtd feature) per day.
   #
   # @return [User, nil] a random user included in the session.
   def random_user

--- a/src/user.rb
+++ b/src/user.rb
@@ -116,11 +116,23 @@ class User
     reset_rtd_count
   end
 
+  # Increments the rtd counter of this user by 1.
+  #
+  # @info: The rtd (roll the dice) counter determines
+  #   the number of random links a user may receive by the Bot
+  #   a day.
   def inc_rtd
     @rtd_count = @rtd_count + 1
   end
 
-  # Set the rtd count equal to 0
+  # Sets the rtd count equal to 0.
+  #
+  # @info: the rtd (roll the dice) counter denotes the number
+  #   of random links a user has received on the current day.
+  #   The notion of rtd count is used in order to limit the number
+  #   of rtd messages a user may receive per day.
+  #   This regularization behaviour is handled
+  #   in Session and PeriodicTask.
   def reset_rtd_count
     @rtd_count = 0
   end
@@ -145,6 +157,10 @@ class User
     @talking_to_cb = !@talking_to_cb
   end
 
+  # Checks whether this user is currently talking to cleverbot.
+  #
+  # @return [Boolean] true in case the user is chatting to cleverbot,
+  #   otherwise false.
   def talking_to_cb?
     @talking_to_cb
   end
@@ -162,6 +178,7 @@ class User
   #
   # @info: Unmovable users will not moved to the afk channel
   #   after being idle for too long.
+  #   A user is unmovable in case he belongs to the server group 'Pigeonator'
   # @return [Boolean] true if this user belongs to the unmovable group
   #   otherwise false.
   def unmovable?

--- a/src/user.rb
+++ b/src/user.rb
@@ -113,11 +113,16 @@ class User
     @unique_id = unique_id
     @is_nil_user = is_nil_user
     @talking_to_cb = true
-    @rtd_count = 0
+    reset_rtd_count
   end
 
   def inc_rtd
     @rtd_count = @rtd_count + 1
+  end
+
+  # Set the rtd count equal to 0
+  def reset_rtd_count
+    @rtd_count = 0
   end
 
   # Checks whether this user the bot?

--- a/src/user.rb
+++ b/src/user.rb
@@ -5,7 +5,7 @@
 # E.g. the logic behing the '!ll' command.
 class User
 
-  attr_reader :id, :nick, :channel_id, :unique_id
+  attr_reader :id, :nick, :channel_id, :unique_id, :rtd_count
   attr_accessor :talking_to_cb
 
   # Threshold time [seconds] a user may be not performing
@@ -113,6 +113,11 @@ class User
     @unique_id = unique_id
     @is_nil_user = is_nil_user
     @talking_to_cb = true
+    @rtd_count = 0
+  end
+
+  def inc_rtd
+    @rtd_count = @rtd_count + 1
   end
 
   # Checks whether this user the bot?


### PR DESCRIPTION
Addresses Issue #72 
- Send every signed in user at most 3 rtd (roll the dice) links a day.
- When a new day starts, reset the rtd counter of every user.

Tested this patch's functionality locally and it seems to work.
